### PR TITLE
Restrict Contact Us Email Domain Validation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -765,7 +765,7 @@
                     
                     <label for="email" class="visually-hidden">Your Email</label>
                     <input type="email" id="email" name="email" placeholder="Your Email" required>
-                    <div id="emailError" class="error-message hidden">Please use an email from a trusted provider.eg: Gmail, Yahoo, Icloud, Hotmail.</div>
+                    <div id="emailError" class="error-message hidden">Please use an email from a trusted provider.eg: Gmail, Outlook, Yahoo, Icloud, Hotmail.</div>
                     
                     <label for="message" class="visually-hidden">Your Message</label>
                     <textarea id="message" name="message" placeholder="Your Message" required></textarea>

--- a/templates/index.html
+++ b/templates/index.html
@@ -373,6 +373,17 @@
             }
         }
              /* Updated CSS for the Contact Form */
+
+             .hidden {
+                display: none;
+            }
+            .error-message {
+                color: red;
+                font-size: 0.9em;
+                margin-top: 5px;
+            }
+
+
              .contact-form {
                 background-color: rgba(255, 255, 255, 0.05);
                 padding: 4rem 2rem;
@@ -747,10 +758,18 @@
                 <center>
                 <h2>Contact Us</h2>
                 <form id="contactForm">
-                    <p>Have questions or Suggest changes? Reach out to our team, and we'll be happy to assist you.</p>
+                    <p>Have questions or suggest changes? Reach out to our team, and we'll be happy to assist you.</p>
+                    
+                    <label for="name" class="visually-hidden">Your Name</label>
                     <input type="text" id="name" name="name" placeholder="Your Name" required>
+                    
+                    <label for="email" class="visually-hidden">Your Email</label>
                     <input type="email" id="email" name="email" placeholder="Your Email" required>
+                    <div id="emailError" class="error-message hidden">Please use an email from a trusted provider.eg: Gmail, Yahoo, Icloud, Hotmail.</div>
+                    
+                    <label for="message" class="visually-hidden">Your Message</label>
                     <textarea id="message" name="message" placeholder="Your Message" required></textarea>
+                    
                     <button type="submit">Send</button>
                 </form>
                 <div id="confirmationMessage" class="hidden">
@@ -897,6 +916,24 @@
             });
         });
         //for contact us 
+
+        document.getElementById("contactForm").addEventListener("submit", function(event) {
+        const emailInput = document.getElementById("email");
+        const emailError = document.getElementById("emailError");
+        const trustedDomains = ["gmail.com", "outlook.com", "icloud.com", "yahoo.com", "hotmail.com"];
+        
+        // Extract the domain from the email
+        const emailDomain = emailInput.value.split("@")[1];
+        
+        // Check if the domain is in the trusted list
+        if (!trustedDomains.includes(emailDomain)) {
+            emailError.classList.remove("hidden");
+            emailInput.focus();
+            event.preventDefault(); // Prevent form submission
+        } else {
+            emailError.classList.add("hidden");
+        }
+    });
             document.getElementById('contactForm').addEventListener('submit', async function(event) {
             event.preventDefault();
     


### PR DESCRIPTION
closes #24 

**POC** (Screen recording)!

https://mega.nz/file/lXMxWB6A#xBDj2qC4uwxGUmI6_wuhet5BniEgY4YgwygCols8EXM

This PR introduces client-side email domain validation to the "Contact Us" form, allowing only email addresses from trusted providers (Gmail, Outlook, iCloud, Yahoo, and Hotmail). Users attempting to submit the form with untrusted domains will see an error message prompting them to use a trusted email provider.

**Trusted mail services:**

`gmail.com`, `yahoo.com`, `outlook.com`, `icloud.com`, `hotmail.com`.

**Changes:**

- Added JavaScript validation to extract the email domain and compare it against a list of trusted providers.
- Updated HTML structure with an error message element that displays when an untrusted domain is detected.
- Added CSS styling for the error message to make it noticeable and consistent with the form design.

**Verification:**

- Navigate to the "Contact Us" form.
- Enter an email address with an untrusted domain (e.g., `example@unknown.com`).
- Expected Result: Error message displays, and form submission is prevented.
- Enter an email address with a trusted domain (e.g., `example@gmail.com`).
- Expected Result: Form submission proceeds successfully.

_**Kindly add all the labels and assign me!**_ @kvcops  